### PR TITLE
Add writing page and update navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
           <ul class="nav-links">
             <li><a href="#about">About</a></li>
             <li><a href="#pillars">Pillars</a></li>
-            <li><a href="#essays">Essays</a></li>
+            <li><a href="writing.html">Writing</a></li>
             <li><a href="#resources">Resources</a></li>
             <li><a href="#notebook">Notebook</a></li>
             <li><a href="#contact">Contact</a></li>
@@ -70,7 +70,7 @@
               Novel updates, short stories, character sketches, and notes from
               the writing desk.
             </p>
-            <a href="#">Explore writing →</a>
+            <a href="writing.html">Explore writing →</a>
           </article>
           <article class="card">
             <h3>Experiments</h3>
@@ -91,8 +91,8 @@
         </div>
       </section>
 
-      <section id="essays" class="wrap section">
-        <h2>Essay & Journal Ideas</h2>
+      <section id="writing" class="wrap section">
+        <h2>Writing Ideas</h2>
         <div class="grid cols-3">
           <article class="card compact">
             <h3>Creative Life</h3>

--- a/styles.css
+++ b/styles.css
@@ -224,3 +224,49 @@ blockquote {
     align-items: flex-start;
   }
 }
+
+.writing-page {
+  padding: 5rem 0 2.5rem;
+}
+
+.writing-post {
+  overflow: hidden;
+  padding: 0;
+}
+
+.post-cover {
+  width: 100%;
+  height: clamp(220px, 36vw, 420px);
+  object-fit: cover;
+  display: block;
+}
+
+.post-content {
+  padding: 1.25rem;
+}
+
+.writing-post h1 {
+  margin-top: 0;
+}
+
+.expandable-text {
+  margin-top: 1rem;
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+}
+
+.expandable-text summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #1e3a8a;
+  width: fit-content;
+}
+
+.expandable-text[open] summary {
+  margin-bottom: 0.8rem;
+}
+
+.expandable-text p {
+  margin: 0.7rem 0;
+  color: #334155;
+}

--- a/writing.html
+++ b/writing.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Writing by Lena Eivy — essays and journal entries on creativity, family life, and the Pacific Northwest."
+    />
+    <title>Lena Eivy | Writing</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="wrap header-row">
+        <a class="brand" href="index.html#top">Lena Eivy</a>
+        <nav aria-label="Primary">
+          <ul class="nav-links">
+            <li><a href="index.html#about">About</a></li>
+            <li><a href="index.html#pillars">Pillars</a></li>
+            <li><a href="writing.html">Writing</a></li>
+            <li><a href="index.html#resources">Resources</a></li>
+            <li><a href="index.html#notebook">Notebook</a></li>
+            <li><a href="index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main id="top" class="wrap writing-page">
+      <article class="writing-post card">
+        <img
+          class="post-cover"
+          src="https://images.unsplash.com/photo-1455390582262-044cdead277a?auto=format&fit=crop&w=1400&q=80"
+          alt="Open notebook and pen on a wood desk"
+        />
+        <div class="post-content">
+          <p class="eyebrow">Featured Writing</p>
+          <h1>Rainy Day Rituals on Vashon Island</h1>
+          <p class="lead">
+            A personal essay about the quiet rhythm of wet mornings, ferry rides,
+            and creative work done slowly.
+          </p>
+
+          <details class="expandable-text">
+            <summary>Expand</summary>
+            <p>
+              Rain begins before dawn here. It gathers on the roof in patient taps,
+              then settles into a soft and steady percussion that feels like
+              permission: stay in, move slower, notice things.
+            </p>
+            <p>
+              By seven, the kettle is singing. The dog has already claimed the warm
+              patch near the heater, and I’ve opened my notebook to a blank page that
+              no longer feels blank. Outside, cedar branches bend and release,
+              bend and release. It looks like breathing.
+            </p>
+            <p>
+              On ferry days, I carry this calm with me. The crossing is short,
+              but it resets something. People stare out the windows, phones forgotten,
+              as if the gray water has asked everyone for one honest minute of silence.
+              I watch reflections slide across the glass and think about stories,
+              and how most of them begin with attention.
+            </p>
+            <p>
+              When I get home, I make another cup of tea and edit what I wrote in the
+              morning. Not to make it perfect—just to make it true. Rainy day rituals
+              are not dramatic. They are small, repeatable acts of care. A notebook.
+              A warm drink. A walk between showers. A few paragraphs that might become
+              something more.
+            </p>
+          </details>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer wrap">
+      <p>© <span id="year">2026</span> Lena Eivy · Built for GitHub Pages.</p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated, blog-style page for writing that opens from the site navigation and the existing "Explore writing" CTA. 
- Surface a featured post with a visible header image and allow readers to expand to read the full text without leaving the site. 

### Description
- Replaced the homepage navigation label/link for `Essays` with `Writing` and pointed the top nav and the pillars card CTA to the new `writing.html` page.
- Renamed the homepage section ID/title from `#essays`/"Essay & Journal Ideas" to `#writing`/"Writing Ideas" to align terminology.
- Added `writing.html`, which contains a featured post layout with a cover image, title, excerpt, and an expandable full-text block using `<details>`/`<summary>`.
- Added supporting styles to `styles.css` for the writing layout, cover image (`.post-cover`), content area (`.post-content`), and expandable section (`.expandable-text`).

### Testing
- Verified updated references with `rg -n "Explore writing|Writing</a>|expand|writing-page|writing.html" index.html writing.html styles.css` and confirmed matches.
- Served the site locally using `python3 -m http.server 8000` and confirmed `writing.html` was reachable at `http://127.0.0.1:8000/writing.html`.
- Automated UI check using Playwright to open `writing.html` and capture a screenshot succeeded and produced `artifacts/writing-page.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b25579988332abdd2ed3a5ad4cbd)