### PR TITLE
Constrain writing post header image height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -238,9 +238,7 @@ blockquote {
 .post-cover {
   width: 100%;
   max-width: 100%;
-  aspect-ratio: 16 / 9;
-  height: auto;
-  max-height: min(52vh, 420px);
+  height: clamp(180px, 28vw, 280px);
   object-fit: cover;
   display: block;
   border-radius: 0.7rem;


### PR DESCRIPTION
### Motivation
- The writing page header image could grow larger than its card and disrupt layout, so the image needs a bounded, responsive height while preserving its crop.

### Description
- Update the `.post-cover` rule to remove `aspect-ratio`, `height: auto`, and `max-height`, and add `height: clamp(180px, 28vw, 280px)` while keeping `object-fit: cover`.

### Testing
- Verified the CSS change with `git diff -- styles.css` and inspected the updated block with `nl -ba styles.css | sed -n '228,258p'`.
- Committed the change successfully with `git commit`.
- Attempted a Playwright screenshot to visually validate the result but the test environment could not load the local page (`ERR_EMPTY_RESPONSE` / `ERR_FILE_NOT_FOUND`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b51d5f048332a21f30facbae0a0b)