### PR TITLE
Add new writing post “AI is teaching our children to cheat.”

### DIFF
--- a/writing.html
+++ b/writing.html
@@ -72,6 +72,230 @@
           </details>
         </div>
       </article>
+
+
+      <article class="writing-post card">
+        <img
+          class="post-cover"
+          src="https://images.unsplash.com/photo-1503676260728-1c00da094a0b?auto=format&fit=crop&w=1400&q=80"
+          alt="Students in a classroom using laptops"
+        />
+        <div class="post-content">
+          <p class="eyebrow">Latest Writing</p>
+          <h1>AI is teaching our children to cheat.</h1>
+
+          <details class="expandable-text">
+            <summary>Expand</summary>
+          <p><strong>“AI is teaching our children to cheat.”</strong></p>
+          <p>
+            I can’t tell you how many times I’ve heard this lately—on Facebook, in
+            casual conversations with friends, in worried discussions about the
+            future of education.
+          </p>
+          <p>
+            A conservative estimate suggests that 11% of college papers now contain
+            at least 20% AI-generated content.
+          </p>
+          <p>
+            So the question becomes: How do we stop our children from cheating
+            themselves out of an education?
+          </p>
+          <p>
+            As an educator with a master’s degree in teaching, I’ve spent a lot of
+            time thinking about this. But something about the premise of the
+            argument has never sat quite right with me.
+          </p>
+          <p>
+            For decades—maybe even centuries—we’ve been teaching students to write
+            in highly standardized, formulaic ways. There is the argumentative
+            essay, designed to present and defend a claim. The persuasive essay,
+            meant to convince a reader of a viewpoint. The personal narrative. The
+            descriptive essay. The expository essay.
+          </p>
+          <p>
+            Each type of essay serves a purpose, but each also follows a
+            predictable structure.
+          </p>
+          <p>
+            When I helped high school students write their college admission
+            essays, I prided myself on being able to break those structures down
+            into something almost mechanical.
+          </p>
+          <ul>
+            <li>Start with a hook.</li>
+            <li>Add a personal anecdote.</li>
+            <li>Vary sentence structure and vocabulary.</li>
+            <li>Insert theme.</li>
+            <li>Check grammar and conventions.</li>
+          </ul>
+          <p>
+            It became a checklist—a formula that could reliably produce an essay
+            polished enough to impress admissions committees.
+          </p>
+          <p>
+            But if the “perfect essay” is essentially a formula that can be
+            reproduced on demand, is it really surprising that students are now
+            outsourcing that formula to a machine that can produce it in seconds?
+          </p>
+          <p>
+            AI has become so effective at generating these essays that the
+            technology designed to detect it has struggled to keep up. And whenever
+            we begin investing large amounts of time and energy into proving that a
+            human—not a machine—did the work, I find myself asking a deeper
+            question:
+          </p>
+          <p><strong>Why?</strong></p>
+          <p>
+            Why are we teaching students to produce writing that a machine can
+            generate just as well—if not better?
+          </p>
+          <p>
+            Why do we care so much that the words came from a human brain rather
+            than an algorithm?
+          </p>
+          <p>What is the true purpose of these assignments?</p>
+          <p>
+            I’m not suggesting there are no good answers to these questions. But I
+            do think we need to ask them honestly.
+          </p>
+          <p>
+            Because AI isn’t going anywhere. Students will always have access to
+            it. So why are we focusing so heavily on teaching students to do
+            something a machine can now do more efficiently?
+          </p>
+          <p>
+            Personally, I have never been asked to write an argumentative essay
+            outside of school. I’ve never needed to produce a persuasive essay
+            structured like the ones I learned in English class.
+          </p>
+          <p>But I write all the time.</p>
+          <ul>
+            <li>I write marketing emails for my business.</li>
+            <li>I write social media posts.</li>
+            <li>I write website copy.</li>
+            <li>I write reflections and ideas.</li>
+          </ul>
+          <p>
+            Ironically, AI has been far more helpful in teaching me those
+            real-world writing skills than school ever was.
+          </p>
+          <p>School never taught me how to write a marketing email. AI did.</p>
+          <p>
+            School never taught me how to craft social media copy for a small
+            business. AI did.
+          </p>
+          <p>
+            So why does our educational system continue to focus so heavily on
+            producing academic essays—while simultaneously condemning the very tool
+            that can produce them most efficiently?
+          </p>
+          <p>Which leads to a bigger question.</p>
+          <p><strong>What is the purpose of school?</strong></p>
+          <p>
+            It’s widely understood that modern schooling systems took shape during
+            the Industrial Revolution, designed in part to prepare students for
+            factory work. And what’s striking is how little the basic structure has
+            changed in the past hundred years.
+          </p>
+          <p>Yes, curricula have evolved.</p>
+          <p>Yes, teaching strategies have improved.</p>
+          <p>But the core model remains the same:</p>
+          <p>
+            Put a group of students the same age in a room and have a teacher tell
+            them what they need to learn.
+          </p>
+          <p>
+            I spent years inside this system—first as a student, then as a
+            teacher. But increasingly, it feels like a paradigm that no longer
+            serves the world we actually live in.
+          </p>
+          <p>In many ways, it’s holding us back.</p>
+          <p>
+            Instead of focusing on writing the “perfect paper” or memorizing the
+            correct answers to pass a test, we should be focusing on the purpose
+            beneath those tasks.
+          </p>
+          <p>
+            If writing essays is meant to develop critical thinking, then let’s
+            focus on teaching critical thinking.
+          </p>
+          <p>
+            If the goal is to learn how to communicate ideas clearly, then let’s
+            teach communication in the contexts people actually use.
+          </p>
+          <p>
+            There are countless ways to develop analytical thinking that don’t
+            involve writing a five-paragraph persuasive essay. There are countless
+            ways to explore ideas without memorizing information that will soon be
+            forgotten.
+          </p>
+          <p>Students will always be able to look up information.</p>
+          <p>They will always have tools that can help generate writing.</p>
+          <p>
+            What we need to teach them is how to think, how to question, and how to
+            apply the tools available to them.
+          </p>
+          <p>
+            In other words, we should be focusing on producing thinkers, not simply
+            compliant participants in an outdated system.
+          </p>
+          <p>
+            I currently homeschool my daughter—but not in the traditional sense of
+            recreating school at home with desks, textbooks, and daily assignments.
+          </p>
+          <p>Instead, I started by asking a fundamental question:</p>
+          <p>What do I actually want her to gain from an education?</p>
+          <p>
+            Do I want her to memorize information long enough to pass a test, only
+            to forget it a week later?
+          </p>
+          <p>
+            Do I want her to wait passively to be told what she should learn each
+            day?
+          </p>
+          <p>
+            Do I want to force her through calculus when she has no interest in
+            pursuing a field that requires advanced mathematics?
+          </p>
+          <p>Absolutely not.</p>
+          <p>
+            What I want is to raise a person who is excited about learning. Someone
+            who sets her own goals and eagerly seeks out the information she needs
+            to achieve them.
+          </p>
+          <p>I want her to be adaptable.</p>
+          <p>
+            I want her to see failure as part of the process, not as a verdict on
+            her worth.
+          </p>
+          <p>And in that context, AI is simply another tool.</p>
+          <p>The goal is not to produce a flawless persuasive essay.</p>
+          <p>
+            The goal—at least right now—is for her to work at a planetarium,
+            teaching children about the stars. If someday she decides that writing a
+            persuasive essay is necessary to reach that goal, then we can learn how
+            to do that together.
+          </p>
+          <p>
+            Maybe we’ll even ask AI to generate one and analyze it—dissecting what
+            works, what doesn’t, and how it could be improved.
+          </p>
+          <p>Because AI isn’t the enemy.</p>
+          <p>It’s a tool.</p>
+          <p>And tools don’t replace human thinking—they amplify it.</p>
+          <p>
+            The ability to dream, to question, to imagine new possibilities, and to
+            pursue meaningful goals is something we cannot outsource to a machine.
+          </p>
+          <p>Nor should we want to.</p>
+          <p>Those abilities are what make us human.</p>
+          <p>
+            And if education is truly meant to prepare the next generation for the
+            future, then those are the things we should be teaching.
+          </p>
+          </details>
+        </div>
+      </article>
     </main>
 
     <footer class="site-footer wrap">


### PR DESCRIPTION
### Motivation
- Add a new long-form writing post to the site to publish a piece about AI and education aimed at readers interested in teaching and learning.
- Surface the post as the site’s "Latest Writing" entry with a cover image and expandable content for better UX on the `writing.html` page.

### Description
- Insert a new `<article>` block in `writing.html` with classes `writing-post card` containing a `post-cover` image and `post-content` wrapper. 
- Add an eyebrow label (`Latest Writing`), a headline (`AI is teaching our children to cheat.`), and an expandable `<details>` element with the full post content including paragraphs and lists.
- Use an Unsplash cover image via the provided URL and include descriptive `alt` text for accessibility.
- The change is purely HTML content addition and does not modify application logic or stylesheets.

### Testing
- No automated tests were run for this content-only HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b71bd5cc8332af572038b2536cc9)