### PR TITLE
Simplify primary nav by removing About, Pillars, and Notebook links

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,11 +16,8 @@
         <a class="brand" href="#top">Lena Eivy</a>
         <nav aria-label="Primary">
           <ul class="nav-links">
-            <li><a href="#about">About</a></li>
-            <li><a href="#pillars">Pillars</a></li>
             <li><a href="writing.html">Writing</a></li>
             <li><a href="#resources">Resources</a></li>
-            <li><a href="#notebook">Notebook</a></li>
             <li><a href="#contact">Contact</a></li>
           </ul>
         </nav>

--- a/writing.html
+++ b/writing.html
@@ -16,11 +16,8 @@
         <a class="brand" href="index.html#top">Lena Eivy</a>
         <nav aria-label="Primary">
           <ul class="nav-links">
-            <li><a href="index.html#about">About</a></li>
-            <li><a href="index.html#pillars">Pillars</a></li>
             <li><a href="writing.html">Writing</a></li>
             <li><a href="index.html#resources">Resources</a></li>
-            <li><a href="index.html#notebook">Notebook</a></li>
             <li><a href="index.html#contact">Contact</a></li>
           </ul>
         </nav>


### PR DESCRIPTION
### Motivation
- Simplify the primary navigation by removing the `About`, `Pillars`, and `Notebook` entries from the main menu on site pages.

### Description
- Removed the `<li>` nav items for `About`, `Pillars`, and `Notebook` from the primary navigation in `index.html` and `writing.html`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c4762f948332af8381aba0146aaa)