### PR TITLE
Remove Writing Ideas section from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,36 +88,6 @@
         </div>
       </section>
 
-      <section id="writing" class="wrap section">
-        <h2>Writing Ideas</h2>
-        <div class="grid cols-3">
-          <article class="card compact">
-            <h3>Creative Life</h3>
-            <ul>
-              <li>Why candid photos matter</li>
-              <li>Learning watercolor as an adult</li>
-              <li>Creativity after 40</li>
-            </ul>
-          </article>
-          <article class="card compact">
-            <h3>Family + Unschooling</h3>
-            <ul>
-              <li>Teaching business math to teens</li>
-              <li>What unschooling actually looks like</li>
-              <li>Preparing teens for adulthood</li>
-            </ul>
-          </article>
-          <article class="card compact">
-            <h3>Pacific Northwest Life</h3>
-            <ul>
-              <li>Ferry reflections</li>
-              <li>Vashon Island quiet moments</li>
-              <li>Rainy day rituals</li>
-            </ul>
-          </article>
-        </div>
-      </section>
-
       <section id="resources" class="wrap section">
         <h2>Resource Library</h2>
         <p>


### PR DESCRIPTION
### Motivation
- Simplify the homepage by removing the standalone "Writing Ideas" block so the page flows directly from the creative pillars to the resource library.

### Description
- Deleted the entire `<section id="writing">` block from `index.html`, removing the "Writing Ideas" heading and its three article columns.
- Left all other markup, IDs, and styles unchanged so the rest of the homepage structure is preserved.

### Testing
- Ran `rg -n "Writing Ideas" index.html` and confirmed there are no remaining matches (success).
- Launched a local static server with `python3 -m http.server` and confirmed it started (success).
- Captured a full-page screenshot of `index.html` with Playwright and produced `artifacts/home-no-writing-ideas.png` (success).
- Ran `git status --short` to verify the working tree is clean after the change (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e43499cc8332902cec8392b8c619)