### PR TITLE
Add Creative Playground, pillar cards, and interactive theme/prompt behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
         <nav aria-label="Primary">
           <ul class="nav-links">
             <li><a href="writing.html">Writing</a></li>
+            <li><a href="#pillars">Creative Pillars</a></li>
+            <li><a href="#playground">Playground</a></li>
             <li><a href="#resources">Resources</a></li>
             <li><a href="#contact">Contact</a></li>
           </ul>
@@ -33,11 +35,11 @@
         </h1>
         <p class="lead">
           This is my home base for creative work and thoughtful living in the
-          Pacific Northwest.
+          Pacific Northwest. Browse, play, and explore the studio.
         </p>
         <div class="hero-actions">
           <a class="button" href="#pillars">Explore the studio</a>
-          <a class="button button-ghost" href="#contact">Get in touch</a>
+          <a class="button button-ghost" href="#playground">Launch interactive mode</a>
         </div>
       </section>
 
@@ -53,7 +55,7 @@
       <section id="pillars" class="wrap section">
         <h2>Four Creative Pillars</h2>
         <div class="grid cols-2">
-          <article class="card">
+          <article class="card pillar-card pillar-photo">
             <h3>Photography</h3>
             <p>
               Documentary-style images focused on real moments, family stories,
@@ -61,7 +63,7 @@
             </p>
             <a href="http://wildlightstories.com">Visit Wildlight Stories →</a>
           </article>
-          <article class="card">
+          <article class="card pillar-card pillar-writing">
             <h3>Writing</h3>
             <p>
               Novel updates, short stories, character sketches, and notes from
@@ -69,37 +71,53 @@
             </p>
             <a href="writing.html">Explore writing →</a>
           </article>
-          <article class="card">
+          <article class="card pillar-card pillar-experiments">
             <h3>Experiments</h3>
             <p>
               A low-pressure lab for app ideas, AI tools, storytelling formats,
               and curious side projects.
             </p>
-            <a href="#">Enter Lena’s Lab →</a>
+            <a href="#playground">Enter Lena’s Lab →</a>
           </article>
-          <article class="card">
-            <h3>Resources</h3>
+          <article class="card pillar-card pillar-resources">
+            <h3>Visual Art</h3>
             <p>
-              Useful tools including business math materials for teens, planner
-              pages, and journaling prompts.
+              A gallery space for sketchbooks, mixed-media studies, and curated
+              art resources that support your creative practice.
             </p>
-            <a href="#">Browse resources →</a>
+            <a href="#resources">Explore visual art →</a>
           </article>
         </div>
       </section>
 
-      <section id="resources" class="wrap section">
-        <h2>Resource Library</h2>
+      <section id="playground" class="wrap section playful-zone">
+        <h2>Creative Playground</h2>
         <p>
-          A growing collection of practical downloads and exercises for creative
-          and family life.
+          Choose your vibe, get a random prompt, and watch the page shift to match your mood.
+        </p>
+        <div class="play-controls">
+          <button id="theme-toggle" class="button" type="button">Switch color vibe</button>
+          <button id="new-prompt" class="button button-ghost" type="button">Give me a prompt</button>
+        </div>
+        <div class="prompt-box card" aria-live="polite">
+          <p id="prompt-text">
+            Prompt: Photograph an ordinary object as if it belongs in a fantasy novel.
+          </p>
+        </div>
+      </section>
+
+      <section id="resources" class="wrap section">
+        <h2>Visual Art Library</h2>
+        <p>
+          A growing collection of sketchbook pages, art studies, and practical
+          resources for makers and visual storytellers.
         </p>
         <ul class="pill-list">
-          <li>Business math curriculum for teens</li>
-          <li>Budget templates</li>
-          <li>Creative journaling prompts</li>
-          <li>Photography reflection exercises</li>
-          <li>Unschooling planner pages</li>
+          <li>Sketchbook flip-through highlights</li>
+          <li>Mixed-media material guides</li>
+          <li>Visual journaling prompts</li>
+          <li>Color studies and composition exercises</li>
+          <li>Favorite art resources and references</li>
         </ul>
       </section>
 
@@ -147,5 +165,7 @@
     <footer class="site-footer wrap">
       <p>© <span id="year">2026</span> Lena Eivy · Built for GitHub Pages.</p>
     </footer>
+
+    <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,30 @@
+const prompts = [
+  "Prompt: Photograph an ordinary object as if it belongs in a fantasy novel.",
+  "Prompt: Write five lines of dialogue between your present self and your 10-year-old self.",
+  "Prompt: Capture one image that feels like a memory from a film that doesn't exist.",
+  "Prompt: Build a tiny story using only three colors and one weather condition.",
+  "Prompt: Find a shadow, and make it the main character."
+];
+
+const year = document.getElementById("year");
+if (year) {
+  year.textContent = String(new Date().getFullYear());
+}
+
+const promptButton = document.getElementById("new-prompt");
+const promptText = document.getElementById("prompt-text");
+if (promptButton && promptText) {
+  promptButton.addEventListener("click", () => {
+    const selection = prompts[Math.floor(Math.random() * prompts.length)];
+    promptText.textContent = selection;
+  });
+}
+
+const themeButton = document.getElementById("theme-toggle");
+if (themeButton) {
+  themeButton.addEventListener("click", () => {
+    const isSunset = document.body.dataset.theme === "sunset";
+    document.body.dataset.theme = isSunset ? "" : "sunset";
+    themeButton.textContent = isSunset ? "Switch color vibe" : "Switch to cool blue vibe";
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,16 @@ body {
   line-height: 1.6;
 }
 
+body[data-theme="sunset"] {
+  --bg: #fff7ed;
+  --surface: #fffbf5;
+  --text: #431407;
+  --muted: #9a3412;
+  --border: #fed7aa;
+  --accent: #ea580c;
+  --accent-soft: #ffedd5;
+}
+
 .wrap {
   width: min(100% - 2rem, 980px);
   margin-inline: auto;
@@ -38,6 +48,11 @@ body {
   backdrop-filter: blur(8px);
   background: rgb(248 250 252 / 86%);
   border-bottom: 1px solid var(--border);
+  z-index: 9;
+}
+
+body[data-theme="sunset"] .site-header {
+  background: rgb(255 247 237 / 90%);
 }
 
 .header-row {
@@ -109,17 +124,18 @@ h1 {
   border: 1px solid transparent;
   background: var(--accent);
   color: #fff;
+  cursor: pointer;
 }
 
 .button:hover,
 .button:focus-visible {
-  background: #1e40af;
+  filter: brightness(0.92);
 }
 
 .button-ghost {
   background: var(--accent-soft);
-  color: #1e3a8a;
-  border-color: #bfdbfe;
+  color: color-mix(in srgb, var(--accent), #1e3a8a 45%);
+  border-color: color-mix(in srgb, var(--accent), white 70%);
 }
 
 .section {
@@ -176,6 +192,84 @@ h2 {
   padding: 0.9rem;
 }
 
+.pillar-card {
+  position: relative;
+  overflow: hidden;
+  min-height: 220px;
+  color: #fff;
+}
+
+.pillar-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  transform: scale(1.02);
+}
+
+.pillar-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgb(15 23 42 / 28%), rgb(15 23 42 / 70%));
+}
+
+.pillar-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.pillar-card h3,
+.pillar-card p,
+.pillar-card a {
+  color: #fff;
+}
+
+.pillar-card a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.pillar-photo::before {
+  background-image: url("https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?auto=format&fit=crop&w=1200&q=80");
+}
+
+.pillar-writing::before {
+  background-image: url("https://images.unsplash.com/photo-1455390582262-044cdead277a?auto=format&fit=crop&w=1200&q=80");
+}
+
+.pillar-experiments::before {
+  background-image: url("https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=1200&q=80");
+}
+
+.pillar-resources::before {
+  background-image: url("https://images.unsplash.com/photo-1434030216411-0b793f4b4173?auto=format&fit=crop&w=1200&q=80");
+}
+
+.playful-zone {
+  background: linear-gradient(135deg, rgb(59 130 246 / 8%), rgb(236 72 153 / 8%));
+  border: 1px dashed color-mix(in srgb, var(--accent), white 75%);
+  border-radius: 1rem;
+  padding: 1.4rem;
+}
+
+.play-controls {
+  display: flex;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.prompt-box {
+  margin-top: 0.9rem;
+  border-left: 4px solid var(--accent);
+}
+
+#prompt-text {
+  margin: 0;
+  font-weight: 500;
+}
+
 .pill-list {
   list-style: none;
   padding: 0;
@@ -223,9 +317,9 @@ blockquote {
     flex-direction: column;
     align-items: flex-start;
   }
-}
 
-.writing-page {
+  @media (max-width: 560px) {
+  .writing-page {
   padding: 5rem 0 2.5rem;
 }
 


### PR DESCRIPTION
### Motivation
- Introduce a small interactive "Creative Playground" to encourage engagement with prompts and visual modes.
- Refresh the site’s homepage to highlight four creative pillars with visual card treatments and updated resource wording.
- Provide lightweight client-side behavior for theme toggling and dynamic prompts and to keep the footer year current.

### Description
- Updated `index.html` to add new nav links, convert the Resources pillar to Visual Art, add a `#playground` section with controls, and include `script.js` before `</body>`.
- Added `script.js` which populates the year, provides a randomized prompt generator for `#new-prompt`, and toggles a `data-theme="sunset"` state with updated button text.
- Enhanced `styles.css` with a sunset theme (`body[data-theme="sunset"]`), pillar card visuals using `::before/::after` backgrounds, `.playful-zone` styles, and minor UI polish (button cursor, hover effect, responsive adjustments).
- Small copy updates in the hero and resource sections and changed several pillar links to point to the new playground or existing pages.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e81a50b0833297a1c565cb7bce09)