### PR TITLE
Add Goodreads “Currently” card to show latest rated book via RSS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ python3 -m http.server 8080
 
 Then open <http://localhost:8080>.
 
+## Goodreads "Currently" integration
+
+The "Currently" card fetches Goodreads account `2174227-lena` and displays the most recently rated book (title, cover, and star rating) from the `read` shelf.
+
+The site fetches the Goodreads RSS feed via an HTTPS proxy and renders the newest entry with a `user_rating` value.
+
 ## GitHub Pages deployment
 
 A GitHub Actions workflow is included at `.github/workflows/deploy.yml`.

--- a/index.html
+++ b/index.html
@@ -135,7 +135,19 @@
           <article class="card compact">
             <h3>Currently</h3>
             <ul>
-              <li><strong>Reading:</strong> Essays on creative process</li>
+              <li>
+                <strong>Most recently rated:</strong>
+                <div id="goodreads-current" data-goodreads-user-id="2174227-lena" data-goodreads-shelf="read">
+                  <p id="goodreads-status">Loading your latest Goodreads rating…</p>
+                  <figure class="goodreads-book" hidden>
+                    <img id="goodreads-cover" alt="" loading="lazy" />
+                    <figcaption>
+                      <p id="goodreads-title"></p>
+                      <p id="goodreads-rating"></p>
+                    </figcaption>
+                  </figure>
+                </div>
+              </li>
               <li><strong>Learning:</strong> Watercolor techniques</li>
               <li><strong>Working on:</strong> Novel draft + photo journal</li>
             </ul>

--- a/script.js
+++ b/script.js
@@ -28,3 +28,84 @@ if (themeButton) {
     themeButton.textContent = isSunset ? "Switch color vibe" : "Switch to cool blue vibe";
   });
 }
+
+const goodreadsCurrent = document.getElementById("goodreads-current");
+if (goodreadsCurrent) {
+  const userId = goodreadsCurrent.dataset.goodreadsUserId || "2174227-lena";
+  const shelf = goodreadsCurrent.dataset.goodreadsShelf || "read";
+  const status = document.getElementById("goodreads-status");
+  const book = goodreadsCurrent.querySelector(".goodreads-book");
+  const cover = document.getElementById("goodreads-cover");
+  const title = document.getElementById("goodreads-title");
+  const rating = document.getElementById("goodreads-rating");
+
+  const setStatus = (message) => {
+    if (status) {
+      status.textContent = message;
+    }
+  };
+
+  const extractText = (parent, tagName) =>
+    parent.querySelector(tagName)?.textContent?.trim() || "";
+
+  if (userId) {
+    const feedUrl = `https://www.goodreads.com/review/list_rss/${encodeURIComponent(userId)}?shelf=${encodeURIComponent(shelf)}&sort=date_updated&order=d`;
+    const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(feedUrl)}`;
+
+    setStatus("Loading your latest Goodreads rating…");
+
+    fetch(proxyUrl)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Feed request failed (${response.status})`);
+        }
+
+        return response.text();
+      })
+      .then((xmlString) => {
+        const xml = new DOMParser().parseFromString(xmlString, "application/xml");
+        const items = Array.from(xml.querySelectorAll("item"));
+        const item = items.find((entry) => Number(extractText(entry, "user_rating")) > 0);
+
+        if (!item) {
+          throw new Error("No rated books found in Goodreads feed");
+        }
+
+        const bookTitle = extractText(item, "book_title") || extractText(item, "title");
+        const userRating = extractText(item, "user_rating");
+        const coverUrl =
+          extractText(item, "book_large_image_url") ||
+          extractText(item, "book_image_url") ||
+          extractText(item, "book_small_image_url");
+
+        if (title) {
+          title.textContent = bookTitle || "Untitled book";
+        }
+
+        if (rating) {
+          rating.textContent = userRating
+            ? `Your rating: ${"★".repeat(Number(userRating))}${"☆".repeat(5 - Number(userRating))} (${userRating}/5)`
+            : "Your rating: Not rated yet";
+        }
+
+        if (cover && coverUrl) {
+          cover.src = coverUrl;
+          cover.alt = `Cover of ${bookTitle || "your latest rated book"}`;
+        } else if (cover) {
+          cover.removeAttribute("src");
+          cover.alt = "";
+        }
+
+        if (book) {
+          book.hidden = false;
+        }
+
+        if (status) {
+          status.hidden = true;
+        }
+      })
+      .catch(() => {
+        setStatus("Couldn’t load Goodreads ratings right now. Please try again in a moment.");
+      });
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -192,6 +192,47 @@ h2 {
   padding: 0.9rem;
 }
 
+#goodreads-current {
+  margin-top: 0.4rem;
+}
+
+#goodreads-status {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.goodreads-book {
+  margin: 0.55rem 0 0;
+  display: flex;
+  gap: 0.7rem;
+  align-items: flex-start;
+}
+
+#goodreads-cover {
+  width: 64px;
+  height: 96px;
+  object-fit: cover;
+  border-radius: 0.35rem;
+  border: 1px solid var(--border);
+  background: #f1f5f9;
+  flex-shrink: 0;
+}
+
+.goodreads-book figcaption p {
+  margin: 0;
+}
+
+#goodreads-title {
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+#goodreads-rating {
+  color: var(--muted);
+  margin-top: 0.2rem;
+}
+
 .pillar-card {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
### Motivation

- Surface the most recently rated Goodreads book on the homepage as a lightweight “Currently” card so visitors can see the latest read without requiring server-side code. 

### Description

- Add markup for a `#goodreads-current` card in `index.html` and set default attributes `data-goodreads-user-id="2174227-lena"` and `data-goodreads-shelf="read"` for the integration.  
- Implement client-side fetching and parsing in `script.js` that requests the Goodreads review RSS via an HTTPS proxy (`https://api.allorigins.win`), finds the newest entry with a `user_rating`, and updates the DOM with the book title, cover, and a star-based rating string.  
- Add styles in `styles.css` for `#goodreads-current`, `.goodreads-book`, `#goodreads-cover`, `#goodreads-title`, and `#goodreads-rating` to match the site’s card layout.  
- Document the feature in `README.md` under a new section `## Goodreads "Currently" integration` describing the account and behavior. 

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5edff77f88332b9c577a5a389ff76)