### PR TITLE
Fix Goodreads widget feed fetching and parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Then open <http://localhost:8080>.
 
 ## Goodreads "Currently" integration
 
-The "Currently" card fetches Goodreads account `2174227-lena` and displays the most recently rated book (title, cover, and star rating) from the `read` shelf.
+The "Currently" card fetches Goodreads account `2174227` and displays the most recently rated book (title, cover, and star rating) from the `read` shelf.
 
-The site fetches the Goodreads RSS feed via an HTTPS proxy and renders the newest entry with a `user_rating` value.
+The site fetches the Goodreads RSS feed via HTTPS proxies (with failover) and renders the newest entry with a `user_rating` value.
 
 ## GitHub Pages deployment
 

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
             <ul>
               <li>
                 <strong>Most recently rated:</strong>
-                <div id="goodreads-current" data-goodreads-user-id="2174227-lena" data-goodreads-shelf="read">
+                <div id="goodreads-current" data-goodreads-user-id="2174227" data-goodreads-shelf="read">
                   <p id="goodreads-status">Loading your latest Goodreads rating…</p>
                   <figure class="goodreads-book" hidden>
                     <img id="goodreads-cover" alt="" loading="lazy" />

--- a/script.js
+++ b/script.js
@@ -31,7 +31,7 @@ if (themeButton) {
 
 const goodreadsCurrent = document.getElementById("goodreads-current");
 if (goodreadsCurrent) {
-  const userId = goodreadsCurrent.dataset.goodreadsUserId || "2174227-lena";
+  const userId = goodreadsCurrent.dataset.goodreadsUserId || "2174227";
   const shelf = goodreadsCurrent.dataset.goodreadsShelf || "read";
   const status = document.getElementById("goodreads-status");
   const book = goodreadsCurrent.querySelector(".goodreads-book");
@@ -45,25 +45,54 @@ if (goodreadsCurrent) {
     }
   };
 
-  const extractText = (parent, tagName) =>
-    parent.querySelector(tagName)?.textContent?.trim() || "";
+  const extractText = (parent, tagName) => {
+    const escapedTag = typeof CSS !== "undefined" && CSS.escape ? CSS.escape(tagName) : tagName;
+
+    return (
+      parent.querySelector(escapedTag)?.textContent?.trim() ||
+      parent.getElementsByTagName(tagName)?.[0]?.textContent?.trim() ||
+      ""
+    );
+  };
 
   if (userId) {
     const feedUrl = `https://www.goodreads.com/review/list_rss/${encodeURIComponent(userId)}?shelf=${encodeURIComponent(shelf)}&sort=date_updated&order=d`;
-    const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(feedUrl)}`;
+    const proxyUrls = [
+      `https://api.allorigins.win/raw?url=${encodeURIComponent(feedUrl)}`,
+      `https://cors.isomorphic-git.org/${feedUrl}`
+    ];
+
+    const fetchFeed = async () => {
+      for (const proxyUrl of proxyUrls) {
+        try {
+          const response = await fetch(proxyUrl);
+          if (!response.ok) {
+            continue;
+          }
+
+          const xmlText = await response.text();
+          if (xmlText) {
+            return xmlText;
+          }
+        } catch {
+          // Try next proxy.
+        }
+      }
+
+      throw new Error("Feed request failed for all proxy endpoints");
+    };
 
     setStatus("Loading your latest Goodreads rating…");
 
-    fetch(proxyUrl)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`Feed request failed (${response.status})`);
-        }
-
-        return response.text();
-      })
+    fetchFeed()
       .then((xmlString) => {
         const xml = new DOMParser().parseFromString(xmlString, "application/xml");
+        const parserError = xml.querySelector("parsererror");
+
+        if (parserError) {
+          throw new Error("Goodreads feed returned invalid XML");
+        }
+
         const items = Array.from(xml.querySelectorAll("item"));
         const item = items.find((entry) => Number(extractText(entry, "user_rating")) > 0);
 


### PR DESCRIPTION
### Motivation
- The Goodreads “Currently” widget was failing intermittently when the RSS endpoint and XML parsing encountered edge cases or CORS/proxy failures.
- The change aims to make feed loading more resilient and to ensure the widget reliably shows the most-recent rated book.

### Description
- Switched the Goodreads ID in markup and JS from the slug `2174227-lena` to the numeric `2174227` to match the RSS endpoint format (updated `index.html` and `script.js`).
- Added proxy failover by attempting `api.allorigins.win` then `cors.isomorphic-git.org` and introduced an async `fetchFeed` loop that tries each proxy before failing (updated `script.js`).
- Hardened XML parsing with `parsererror` detection and improved tag extraction by using `CSS.escape` when available and falling back to `getElementsByTagName` for more robust element lookup (updated `script.js`).
- Updated `README.md` to reflect the numeric Goodreads account ID and the new proxy failover behavior.

### Testing
- Ran `node --check script.js` which completed successfully.
- Served the site locally with `python3 -m http.server 8080` for manual/browser validation which started successfully.
- Captured a validation screenshot using Playwright; the first Playwright run timed out, a second run succeeded and produced a screenshot confirming the widget markup and script loaded.
- All automated checks listed above passed except the initial Playwright attempt which timed out and was retried successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f05b89bc83329b86c0bf6d8567dd)