### PR TITLE
Change Goodreads “Currently” wording to “reading”

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then open <http://localhost:8080>.
 
 ## Goodreads "Currently" integration
 
-The "Currently" card fetches Goodreads account `2174227` and displays the most recently rated book (title, cover, and star rating) from the `read` shelf.
+The "Currently" card fetches Goodreads account `2174227` and displays the reading book (title, cover, and star rating) from the `read` shelf.
 
 The site fetches the Goodreads RSS feed via HTTPS proxies (with failover) and renders the newest entry with a `user_rating` value.
 


### PR DESCRIPTION
### Motivation
- Simplify the README wording for the Goodreads "Currently" card by replacing "most recently rated" with the clearer term "reading".

### Description
- Updated `README.md` so the "Currently" card description now reads that it "displays the reading book (title, cover, and star rating) from the `read` shelf."

### Testing
- Verified the updated text with `rg -n "most recently rated|reading book" README.md` which returned the new phrase.
- Committed the change with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f19a19708332b462d5595231e82b)