### PR TITLE
Update "Currently" label from "Most recently rated" to "Reading"

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
             <h3>Currently</h3>
             <ul>
               <li>
-                <strong>Most recently rated:</strong>
+                <strong>Reading:</strong>
                 <div id="goodreads-current" data-goodreads-user-id="2174227" data-goodreads-shelf="read">
                   <p id="goodreads-status">Loading your latest Goodreads rating…</p>
                   <figure class="goodreads-book" hidden>


### PR DESCRIPTION
### Motivation
- Update the homepage "Currently" card so the book label reads "Reading:" instead of "Most recently rated:" to better reflect reading status.

### Description
- Modified `index.html` to replace the `<strong>` label in the `#notebook` "Currently" card from `Most recently rated:` to `Reading:`.

### Testing
- Confirmed the change with `rg -n "Reading:" index.html` and served the site locally using `python3 -m http.server 4173`, then captured a browser screenshot with Playwright which loaded the page successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f37d573c8332afe2640714356b4a)