### PR TITLE
Add Visual Art page and styles; wire into navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
         <nav aria-label="Primary">
           <ul class="nav-links">
             <li><a href="writing.html">Writing</a></li>
+            <li><a href="visual-art.html">Visual Art</a></li>
             <li><a href="#pillars">Creative Pillars</a></li>
             <li><a href="#playground">Playground</a></li>
             <li><a href="#resources">Resources</a></li>
@@ -85,7 +86,7 @@
               A gallery space for sketchbooks, mixed-media studies, and curated
               art resources that support your creative practice.
             </p>
-            <a href="#resources">Explore visual art →</a>
+            <a href="visual-art.html">Explore visual art →</a>
           </article>
         </div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -192,6 +192,47 @@ h2 {
   padding: 0.9rem;
 }
 
+
+.visual-grid {
+  gap: 1.1rem;
+}
+
+.media-card {
+  overflow: hidden;
+  padding: 0;
+}
+
+.media-cover {
+  width: 100%;
+  height: clamp(180px, 22vw, 260px);
+  object-fit: cover;
+  display: block;
+  border-bottom: 1px solid var(--border);
+}
+
+.media-content {
+  padding: 0.95rem;
+}
+
+.section-note {
+  color: var(--muted);
+  margin-top: 0;
+  margin-bottom: 0.9rem;
+}
+
+.post-meta {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.sketchbook-post h3,
+.media-content h3 {
+  margin-top: 0.35rem;
+}
+
 #goodreads-current {
   margin-top: 0.4rem;
 }
@@ -345,6 +386,12 @@ blockquote {
   font-size: 0.95rem;
 }
 
+
+.writing-page,
+.visual-art-page {
+  padding: 5rem 0 2.5rem;
+}
+
 @media (max-width: 860px) {
   .cols-3 {
     grid-template-columns: 1fr;
@@ -358,53 +405,54 @@ blockquote {
     flex-direction: column;
     align-items: flex-start;
   }
-
-  @media (max-width: 560px) {
-  .writing-page {
-  padding: 5rem 0 2.5rem;
 }
 
-.writing-post {
-  overflow: hidden;
+@media (max-width: 560px) {
+  .media-cover {
+    height: 180px;
+  }
 
-  padding: clamp(0.75rem, 2vw, 1.25rem);
-}
+  .writing-post {
+    overflow: hidden;
+    padding: clamp(0.75rem, 2vw, 1.25rem);
+  }
 
-.post-cover {
-  width: 100%;
-  max-width: 100%;
-  height: clamp(180px, 28vw, 280px);
-  object-fit: cover;
-  display: block;
-  border-radius: 0.7rem;
-}
+  .post-cover {
+    width: 100%;
+    max-width: 100%;
+    height: clamp(180px, 28vw, 280px);
+    object-fit: cover;
+    display: block;
+    border-radius: 0.7rem;
+  }
 
-.post-content {
-  padding: clamp(0.85rem, 2vw, 1.25rem) 0 0;
-}
+  .post-content {
+    padding: clamp(0.85rem, 2vw, 1.25rem) 0 0;
+  }
 
-.writing-post h1 {
-  margin-top: 0;
-}
+  .writing-post h1 {
+    margin-top: 0;
+  }
 
-.expandable-text {
-  margin-top: 1rem;
-  border-top: 1px solid var(--border);
-  padding-top: 1rem;
-}
+  .expandable-text {
+    margin-top: 1rem;
+    border-top: 1px solid var(--border);
+    padding-top: 1rem;
+  }
 
-.expandable-text summary {
-  cursor: pointer;
-  font-weight: 600;
-  color: #1e3a8a;
-  width: fit-content;
-}
+  .expandable-text summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #1e3a8a;
+    width: fit-content;
+  }
 
-.expandable-text[open] summary {
-  margin-bottom: 0.8rem;
-}
+  .expandable-text[open] summary {
+    margin-bottom: 0.8rem;
+  }
 
-.expandable-text p {
-  margin: 0.7rem 0;
-  color: #334155;
+  .expandable-text p {
+    margin: 0.7rem 0;
+    color: #334155;
+  }
 }

--- a/visual-art.html
+++ b/visual-art.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Visual art by Lena Eivy — favorite books, sketchbook explorations, supplies, and online art teachers."
+    />
+    <title>Lena Eivy | Visual Art</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="wrap header-row">
+        <a class="brand" href="index.html#top">Lena Eivy</a>
+        <nav aria-label="Primary">
+          <ul class="nav-links">
+            <li><a href="writing.html">Writing</a></li>
+            <li><a href="visual-art.html" aria-current="page">Visual Art</a></li>
+            <li><a href="index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main id="top" class="wrap visual-art-page">
+      <section class="section">
+        <p class="eyebrow">Visual Art Studio</p>
+        <h1>A curated corner of my visual art practice.</h1>
+        <p class="lead">
+          These are the books, artists, tools, and sketchbook rhythms that help me stay curious and keep making.
+        </p>
+      </section>
+
+      <section class="section" aria-labelledby="books-i-love">
+        <h2 id="books-i-love">Books I Love</h2>
+        <div class="grid cols-2 visual-grid">
+          <article class="card media-card">
+            <img
+              class="media-cover"
+              src="https://images.unsplash.com/photo-1512820790803-83ca734da794?auto=format&fit=crop&w=1200&q=80"
+              alt="Stack of colorful books on a table"
+              loading="lazy"
+            />
+            <div class="media-content">
+              <h3>Steal Like an Artist</h3>
+              <p>A practical reminder that creativity grows from collecting ideas, remixing them, and showing up daily.</p>
+            </div>
+          </article>
+          <article class="card media-card">
+            <img
+              class="media-cover"
+              src="https://images.unsplash.com/photo-1495446815901-a7297e633e8d?auto=format&fit=crop&w=1200&q=80"
+              alt="Open art and design books next to a coffee cup"
+              loading="lazy"
+            />
+            <div class="media-content">
+              <h3>The Creative Act</h3>
+              <p>A grounding read that helps me return to process, intuition, and curiosity over perfection.</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="explore-my-sketchbook">
+        <h2 id="explore-my-sketchbook">Explore My Sketchbook</h2>
+        <p class="section-note">Set up like a visual blog: each entry has an image, title, and short note.</p>
+        <div class="grid cols-2 visual-grid">
+          <article class="card sketchbook-post">
+            <img
+              class="media-cover"
+              src="https://images.unsplash.com/photo-1513364776144-60967b0f800f?auto=format&fit=crop&w=1200&q=80"
+              alt="Sketchbook page with watercolor swatches"
+              loading="lazy"
+            />
+            <div class="media-content">
+              <p class="post-meta">March 2026</p>
+              <h3>Rain Palette Studies</h3>
+              <p>Testing cool grays and moss greens from this week’s ferry rides.</p>
+            </div>
+          </article>
+          <article class="card sketchbook-post">
+            <img
+              class="media-cover"
+              src="https://images.unsplash.com/photo-1455390582262-044cdead277a?auto=format&fit=crop&w=1200&q=80"
+              alt="Notebook and pencil beside loose sketches"
+              loading="lazy"
+            />
+            <div class="media-content">
+              <p class="post-meta">February 2026</p>
+              <h3>Character Gesture Warmups</h3>
+              <p>Quick 2-minute poses to loosen my hand before longer drawing sessions.</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="my-supplies">
+        <h2 id="my-supplies">My Supplies</h2>
+        <div class="grid cols-2 visual-grid">
+          <article class="card media-card">
+            <img
+              class="media-cover"
+              src="https://images.unsplash.com/photo-1452860606245-08befc0ff44b?auto=format&fit=crop&w=1200&q=80"
+              alt="Pens and drawing pencils arranged on a desk"
+              loading="lazy"
+            />
+            <div class="media-content">
+              <h3>Drawing Kit</h3>
+              <ul>
+                <li>Mechanical pencil + 2B lead</li>
+                <li>Kneaded eraser</li>
+                <li>Pigment liner set</li>
+              </ul>
+            </div>
+          </article>
+          <article class="card media-card">
+            <img
+              class="media-cover"
+              src="https://images.unsplash.com/photo-1460661419201-fd4cecdf8a8b?auto=format&fit=crop&w=1200&q=80"
+              alt="Watercolor pans and paint brushes"
+              loading="lazy"
+            />
+            <div class="media-content">
+              <h3>Painting Kit</h3>
+              <ul>
+                <li>Travel watercolor palette</li>
+                <li>Gouache primaries</li>
+                <li>Round brushes (sizes 2, 6, 10)</li>
+              </ul>
+            </div>
+          </article>
+          <article class="card media-card">
+            <img
+              class="media-cover"
+              src="https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?auto=format&fit=crop&w=1200&q=80"
+              alt="Stacked sketchbooks and textured papers"
+              loading="lazy"
+            />
+            <div class="media-content">
+              <h3>Paper Favorites</h3>
+              <ul>
+                <li>A5 mixed-media sketchbook</li>
+                <li>Cold-press watercolor block</li>
+                <li>Toned paper for value studies</li>
+              </ul>
+            </div>
+          </article>
+          <article class="card media-card">
+            <img
+              class="media-cover"
+              src="https://images.unsplash.com/photo-1509967419530-da38b4704bc6?auto=format&fit=crop&w=1200&q=80"
+              alt="Art desk with lamp, tape, and tools"
+              loading="lazy"
+            />
+            <div class="media-content">
+              <h3>Studio Extras</h3>
+              <ul>
+                <li>Painter's tape</li>
+                <li>Portable daylight lamp</li>
+                <li>Foldable lap desk for couch sketching</li>
+              </ul>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="online-teachers">
+        <h2 id="online-teachers">On-line Teachers I Love</h2>
+        <div class="grid cols-2 visual-grid">
+          <article class="card compact">
+            <h3>Proko</h3>
+            <p>Clear anatomy and drawing fundamentals with a playful teaching style.</p>
+            <a href="https://www.youtube.com/@ProkoTV">Watch tutorials →</a>
+          </article>
+          <article class="card compact">
+            <h3>James Gurney</h3>
+            <p>Incredible demos on color, light, and plein-air storytelling.</p>
+            <a href="https://www.youtube.com/@JamesGurney">Watch tutorials →</a>
+          </article>
+          <article class="card compact">
+            <h3>Sarah Burns Studio</h3>
+            <p>Encouraging sketchbook prompts and accessible mixed-media techniques.</p>
+            <a href="https://www.youtube.com/results?search_query=sarah+burns+studio+art">Watch tutorials →</a>
+          </article>
+          <article class="card compact">
+            <h3>Domestika Instructors</h3>
+            <p>Structured short classes when I want to learn one technique at a time.</p>
+            <a href="https://www.domestika.org/en/courses/area/17-illustration">Browse tutorials →</a>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer wrap">
+      <p>© <span id="year">2026</span> Lena Eivy · Built for GitHub Pages.</p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/writing.html
+++ b/writing.html
@@ -17,6 +17,7 @@
         <nav aria-label="Primary">
           <ul class="nav-links">
             <li><a href="writing.html">Writing</a></li>
+            <li><a href="visual-art.html">Visual Art</a></li>
             <li><a href="index.html#resources">Resources</a></li>
             <li><a href="index.html#contact">Contact</a></li>
           </ul>


### PR DESCRIPTION
### Motivation
- Introduce a dedicated "Visual Art" section to showcase books, sketchbook posts, supplies, and favorite online teachers. 
- Surface the new page from the main site and writing pages so visitors can navigate to the visual art content directly.

### Description
- Add a new `visual-art.html` page containing curated content sections for books, sketchbook entries, supplies, and online teachers with responsive media cards and images. 
- Update `index.html` and `writing.html` to include a "Visual Art" link in the primary navigation and change the Visual Art pillar card to link to `visual-art.html`. 
- Extend `styles.css` with layout and component styles for `.visual-grid`, `.media-card`, `.media-cover`, `.media-content`, `.post-meta`, and responsive adjustments for small screens. 
- Keep consistent header/footer and include `script.js` and `styles.css` references on the new page.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b605e91c04833289807804635d7dde)